### PR TITLE
Add Temporary Directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,3 @@ license = "MIT"
 keywords = ["electronics", "raspberry-pi", "robotics"]
 categories = ["hardware-support", "science::robotics"]
 publish = false
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,1 @@
-
+pub mod temporary_directory;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,5 @@
+//! # Otter Pi
+//!
+//! A robot built on Raspberry Pi.
+
 pub mod temporary_directory;

--- a/src/temporary_directory.rs
+++ b/src/temporary_directory.rs
@@ -97,7 +97,7 @@ impl TemporaryDirectory {
 
 impl Drop for TemporaryDirectory {
     fn drop(&mut self) {
-        let _ = fs::remove_dir(&self.path);
+        let _ = fs::remove_dir_all(&self.path);
     }
 }
 
@@ -120,6 +120,19 @@ mod tests {
     #[test]
     fn it_should_return_a_path_that_does_not_exist_after_it_goes_out_of_scope() {
         let path = TemporaryDirectory::new().unwrap().get_path().to_owned();
+        assert!(path.try_exists().is_ok_and(|exists| !exists));
+    }
+
+    #[test]
+    fn it_should_return_a_path_that_does_not_exist_after_adding_content_and_it_goes_out_of_scope_()
+    {
+        let path = {
+            let temp_dir = TemporaryDirectory::new().unwrap();
+            let file_path = temp_dir.get_path().join("foo");
+            fs::write(file_path, "bar").unwrap();
+            temp_dir.get_path().to_owned()
+        };
+
         assert!(path.try_exists().is_ok_and(|exists| !exists));
     }
 }

--- a/src/temporary_directory.rs
+++ b/src/temporary_directory.rs
@@ -1,0 +1,29 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct TemporaryDirectory {
+    path: PathBuf,
+}
+
+impl TemporaryDirectory {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    #[must_use]
+    pub fn get_path(&self) -> &Path {
+        &self.path
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_should_return_a_path_that_does_not_exist_after_it_goes_out_of_scope() {
+        let path = TemporaryDirectory::new().get_path().to_owned();
+        assert!(path.try_exists().is_ok_and(|exists| !exists));
+    }
+}

--- a/src/temporary_directory.rs
+++ b/src/temporary_directory.rs
@@ -134,4 +134,11 @@ mod tests {
 
         assert!(path.try_exists().is_ok_and(|exists| !exists));
     }
+
+    #[test]
+    fn it_should_return_a_unique_path_for_each_instance() {
+        let temp_dir_a = TemporaryDirectory::new().unwrap();
+        let temp_dir_b = TemporaryDirectory::new().unwrap();
+        assert_ne!(temp_dir_a.get_path(), temp_dir_b.get_path());
+    }
 }

--- a/src/temporary_directory.rs
+++ b/src/temporary_directory.rs
@@ -1,6 +1,7 @@
+use std::env;
 use std::path::{Path, PathBuf};
 
-#[derive(Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TemporaryDirectory {
     path: PathBuf,
 }
@@ -17,9 +18,23 @@ impl TemporaryDirectory {
     }
 }
 
+impl Default for TemporaryDirectory {
+    fn default() -> Self {
+        let mut path = env::temp_dir();
+        path.push("tHiS dIr3cT0rY 1S uN1Ik3Ly T0 3x15t");
+        Self { path }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn it_should_return_a_path_that_begins_with_the_system_temporary_directory() {
+        let temp_dir = TemporaryDirectory::new();
+        assert!(temp_dir.get_path().starts_with(env::temp_dir()));
+    }
 
     #[test]
     fn it_should_return_a_path_that_does_not_exist_after_it_goes_out_of_scope() {

--- a/src/temporary_directory.rs
+++ b/src/temporary_directory.rs
@@ -1,28 +1,103 @@
-use std::env;
-use std::path::{Path, PathBuf};
+//! Abstractions to make managing temporary directories easier.
 
+use std::ffi::{c_char, CString, OsString};
+#[cfg(unix)]
+use std::os::unix::ffi::OsStringExt;
+use std::path::{Path, PathBuf};
+use std::{env, error, fs, io};
+
+extern "C" {
+    fn mkdtemp(template: *mut c_char) -> *mut c_char;
+}
+
+/// A secure, uniquely-named temporary directory.
+///
+/// This is an RAII construct that automatically initializes and finalizes a
+/// temporary directory bound by the lifetime of the object.
+///
+/// # Examples
+///
+/// ```
+/// use otter_pi::temporary_directory::TemporaryDirectory;
+///
+/// let path = {
+///     let temp_dir = TemporaryDirectory::new().unwrap();
+///     assert!(temp_dir.get_path().is_dir());
+///     temp_dir.get_path().to_owned()
+/// };
+///
+/// assert!(path.try_exists().is_ok_and(|exists| !exists));
+/// ```
 #[derive(Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct TemporaryDirectory {
     path: PathBuf,
 }
 
 impl TemporaryDirectory {
-    #[must_use]
-    pub fn new() -> Self {
-        Self::default()
+    /// Securely creates a uniquely-named temporary directory.
+    ///
+    /// The path to the underlying temporary directory is based on the system's
+    /// temporary directory path composed with a random string.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::env;
+    ///
+    /// use otter_pi::temporary_directory::TemporaryDirectory;
+    ///
+    /// let temp_dir = TemporaryDirectory::new().unwrap();
+    /// assert!(temp_dir.get_path().starts_with(env::temp_dir()));
+    /// ```
+    /// # Errors
+    ///
+    /// This function will return an error if the internal path template derived
+    /// from the system temporary directory path contains a nul byte, or if it fails
+    /// to create the underlying temporary directory for any reason.
+    #[cfg(unix)]
+    pub fn new() -> Result<Self, Box<dyn error::Error>> {
+        let mut template = env::temp_dir();
+        template.push("XXXXXX");
+        let template = CString::new(template.into_os_string().into_vec())?;
+        let template = template.into_raw();
+        let ptr = unsafe { mkdtemp(template) };
+        let error = io::Error::last_os_error();
+        let path = unsafe { CString::from_raw(template) };
+
+        if ptr.is_null() {
+            Err(error)?
+        } else {
+            let path = PathBuf::from(OsString::from_vec(path.into_bytes()));
+            Ok(Self { path })
+        }
     }
 
+    /// Returns the path to the underlying temporary directory.
+    ///
+    /// Can be used to compose additional paths to interact with entities within
+    /// the temporary directory.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::fs;
+    ///
+    /// use otter_pi::temporary_directory::TemporaryDirectory;
+    ///
+    /// let temp_dir = TemporaryDirectory::new().unwrap();
+    /// let file_path = temp_dir.get_path().join("foo");
+    /// assert!(fs::write(&file_path, "bar").is_ok());
+    /// assert!(fs::read_to_string(&file_path).is_ok_and(|content| content == "bar"));
+    /// ```
     #[must_use]
     pub fn get_path(&self) -> &Path {
         &self.path
     }
 }
 
-impl Default for TemporaryDirectory {
-    fn default() -> Self {
-        let mut path = env::temp_dir();
-        path.push("tHiS dIr3cT0rY 1S uN1Ik3Ly T0 3x15t");
-        Self { path }
+impl Drop for TemporaryDirectory {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir(&self.path);
     }
 }
 
@@ -32,13 +107,19 @@ mod tests {
 
     #[test]
     fn it_should_return_a_path_that_begins_with_the_system_temporary_directory() {
-        let temp_dir = TemporaryDirectory::new();
+        let temp_dir = TemporaryDirectory::new().unwrap();
         assert!(temp_dir.get_path().starts_with(env::temp_dir()));
     }
 
     #[test]
+    fn it_should_return_a_path_to_an_accessible_directory() {
+        let temp_dir = TemporaryDirectory::new().unwrap();
+        assert!(temp_dir.get_path().is_dir());
+    }
+
+    #[test]
     fn it_should_return_a_path_that_does_not_exist_after_it_goes_out_of_scope() {
-        let path = TemporaryDirectory::new().get_path().to_owned();
+        let path = TemporaryDirectory::new().unwrap().get_path().to_owned();
         assert!(path.try_exists().is_ok_and(|exists| !exists));
     }
 }

--- a/src/temporary_directory.rs
+++ b/src/temporary_directory.rs
@@ -118,14 +118,13 @@ mod tests {
     }
 
     #[test]
-    fn it_should_return_a_path_that_does_not_exist_after_it_goes_out_of_scope() {
+    fn it_should_return_a_path_that_does_not_exist_after_going_out_of_scope() {
         let path = TemporaryDirectory::new().unwrap().get_path().to_owned();
         assert!(path.try_exists().is_ok_and(|exists| !exists));
     }
 
     #[test]
-    fn it_should_return_a_path_that_does_not_exist_after_adding_content_and_it_goes_out_of_scope_()
-    {
+    fn it_should_return_a_path_that_does_not_exist_after_adding_content_and_going_out_of_scope() {
         let path = {
             let temp_dir = TemporaryDirectory::new().unwrap();
             let file_path = temp_dir.get_path().join("foo");


### PR DESCRIPTION
- Add TemporaryDirectory
- Add library documentation
- Tidy up

Adds a `TemporaryDirectory` struct that uses RAII to simplify setup and tear-down of unit tests for components that control logical electrical signals through the Linux kernel sysfs. 

Not every system is equipped with the hardware necessary to control logical electrical signals. There is also a risk of damage to hardware by live testing a system that is not properly configured. Since the sysfs interface is implemented as a virtual file system, being able to create an alternate temporary file system to test against is advantageous.